### PR TITLE
feature :: add underline functionality to RichTextEditor

### DIFF
--- a/frontend/client/components/RichTextEditor.tsx
+++ b/frontend/client/components/RichTextEditor.tsx
@@ -130,6 +130,15 @@ export function RichTextEditor({
             </MenuButton>
 
             <MenuButton
+              onClick={() => editor.chain().focus().toggleUnderline().run()}
+              isActive={editor.isActive('underline')}
+              title="Underline (Ctrl+U)"
+            >
+              <UnderlineIcon className="h-4 w-4" />
+            </MenuButton>
+
+
+            <MenuButton
               onClick={() => editor.chain().focus().toggleItalic().run()}
               isActive={editor.isActive('italic')}
               title="Italic (Ctrl+I)"


### PR DESCRIPTION
## Summary

Currently, the rich text editor supports bold, italic, headings, lists, and code, but it does not provide an underline option. This limits text formatting flexibility for users who expect underline functionality in a modern editor.

## Related Issue
Fixes https://github.com/devayanm/docusphere/issues/29
closes https://github.com/devayanm/docusphere/issues/29

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Other

## Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests where applicable
- [x] I have updated the documentation if necessary
